### PR TITLE
Fix release workflow content permission

### DIFF
--- a/templates/.github/workflows/release.yml
+++ b/templates/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     needs:
       - integration
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/