### PR TITLE
fix: fixes various Windows related issues

### DIFF
--- a/src/libs/git.ts
+++ b/src/libs/git.ts
@@ -15,5 +15,5 @@ export function initGitRepository(repoPath: string) {
 }
 
 export function stageFiles(repoPath: string, files: string[]) {
-  return exec('git', ['add', ...files], { cwd: repoPath, silent: true })
+  return exec('git', ['add', ...files.sort()], { cwd: repoPath, silent: true })
 }

--- a/src/libs/pm.ts
+++ b/src/libs/pm.ts
@@ -1,4 +1,4 @@
-import * as os from 'node:os'
+import os from 'node:os'
 
 import { PACKAGE_MANAGER, PACKAGE_MANAGER_EXECUTE } from '../config'
 
@@ -28,10 +28,15 @@ export function executePackageManagerCommand(appPath: string, args: string[], si
   return runPackageManager(appPath, args, { execute: true, silent: !!silent })
 }
 
+export function getPackageManagerBinary(execute?: RunOptions['execute']) {
+  const executable = execute ? PACKAGE_MANAGER_EXECUTE : PACKAGE_MANAGER
+  const extension = os.platform() === 'win32' ? '.cmd' : ''
+
+  return `${executable}${extension}`
+}
+
 function runPackageManager(appPath: string, args: string[], options: RunOptions = {}) {
-  const cmdExtension = os.platform() === 'win32' ? '.cmd' : ''
-  const executable = options.execute ? PACKAGE_MANAGER_EXECUTE : PACKAGE_MANAGER
-  return exec(`${executable}${cmdExtension}`, args, { ...options, cwd: appPath })
+  return exec(getPackageManagerBinary(options.execute), args, { ...options, cwd: appPath })
 }
 
 interface RunOptions extends ExecOptions {

--- a/src/libs/pm.ts
+++ b/src/libs/pm.ts
@@ -1,3 +1,5 @@
+import * as os from 'node:os'
+
 import { PACKAGE_MANAGER, PACKAGE_MANAGER_EXECUTE } from '../config'
 
 import { exec, type ExecOptions } from './exec'
@@ -27,7 +29,9 @@ export function executePackageManagerCommand(appPath: string, args: string[], si
 }
 
 function runPackageManager(appPath: string, args: string[], options: RunOptions = {}) {
-  return exec(options.execute ? PACKAGE_MANAGER_EXECUTE : PACKAGE_MANAGER, args, { ...options, cwd: appPath })
+  const cmdExtension = os.platform() === 'win32' ? '.cmd' : ''
+  const executable = options.execute ? PACKAGE_MANAGER_EXECUTE : PACKAGE_MANAGER
+  return exec(`${executable}${cmdExtension}`, args, { ...options, cwd: appPath })
 }
 
 interface RunOptions extends ExecOptions {

--- a/src/libs/template.ts
+++ b/src/libs/template.ts
@@ -37,13 +37,13 @@ let templateVariables: TemplateVariables | undefined
 export async function getTemplatePaths(ignoreSpecialTemplates = true) {
   const templatePath = getTemplatesPath()
 
-  const allTemplatePaths = await glob(path.join(templatePath, '**/*'), { absolute: true, dot: true, filesOnly: true })
+  const allTemplatePaths = await glob('**/*', { cwd: templatePath, absolute: true, dot: true, filesOnly: true })
 
   const templates: Template[] = []
 
   for (const absolutePath of allTemplatePaths) {
     const template = {
-      destination: absolutePath.replace(`${templatePath}/`, ''),
+      destination: absolutePath.replace(`${templatePath}${path.sep}`, ''),
       source: absolutePath,
     }
 
@@ -112,7 +112,7 @@ export function compileTemplate(content: string) {
 function getTemplatesPath() {
   const dirName = path.dirname(fileURLToPath(import.meta.url))
 
-  return path.join(dirName, dirName.endsWith('src/libs') ? '../..' : '..', 'templates')
+  return path.join(dirName, dirName.endsWith(path.join('src', 'libs')) ? '../..' : '..', 'templates')
 }
 
 function isValidTemplateVariable(variable: string): variable is keyof TemplateVariables {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,4 +1,6 @@
 import { spawn } from 'node:child_process'
+import os from 'node:os'
+import path from 'node:path'
 
 import type { PackageJson } from 'type-fest'
 import * as undici from 'undici'
@@ -277,6 +279,9 @@ describe.each(testScenarios)('$description', ({ appName, options, setup }) => {
 
   describe('should run various commands', () => {
     const spawnMock = vi.mocked(spawn)
+    const cmdExtension = os.platform() === 'win32' ? '.cmd' : ''
+    const packageManager = `${PACKAGE_MANAGER}${cmdExtension}`
+    const packageManagerExecute = `${PACKAGE_MANAGER_EXECUTE}${cmdExtension}`
 
     afterAll(() => {
       spawnMock.mockClear()
@@ -302,21 +307,21 @@ describe.each(testScenarios)('$description', ({ appName, options, setup }) => {
     })
 
     test('should install dependencies', () => {
-      expectSpawnToHaveBeenNthCalledWith(PACKAGE_MANAGER, ['install'])
+      expectSpawnToHaveBeenNthCalledWith(packageManager, ['install'])
     })
 
     test('should configure Git hooks', () => {
-      expectSpawnToHaveBeenNthCalledWith(PACKAGE_MANAGER_EXECUTE, ['husky', 'init'])
+      expectSpawnToHaveBeenNthCalledWith(packageManagerExecute, ['husky', 'init'])
     })
 
     test('should run ESLint when updating an existing app', () => {
       if (!options.isNew) {
-        expectSpawnToHaveBeenNthCalledWith(PACKAGE_MANAGER, ['exec', 'eslint', '.', '--fix'])
+        expectSpawnToHaveBeenNthCalledWith(packageManager, ['exec', 'eslint', '.', '--fix'])
       }
     })
 
     test('should prettify the app', () => {
-      expectSpawnToHaveBeenNthCalledWith(PACKAGE_MANAGER, ['exec', 'prettier', '-w', '--log-level', 'silent', '.'])
+      expectSpawnToHaveBeenNthCalledWith(packageManager, ['exec', 'prettier', '-w', '--log-level', 'silent', '.'])
     })
 
     test('should check if the repository exists on GitHub', () => {
@@ -359,19 +364,19 @@ describe.each(testScenarios)('$description', ({ appName, options, setup }) => {
     test('should stage new or updated files', () => {
       expectSpawnToHaveBeenNthCalledWith('git', [
         'add',
-        '.github/workflows/integration.yml',
-        '.github/workflows/release.yml',
+        path.join('.github', 'workflows', 'integration.yml'),
+        path.join('.github', 'workflows', 'release.yml'),
         '.gitignore',
-        '.husky/pre-commit',
+        path.join('.husky', 'pre-commit'),
         '.prettierignore',
-        '.vscode/extensions.json',
-        '.vscode/settings.json',
+        path.join('.vscode', 'extensions.json'),
+        path.join('.vscode', 'settings.json'),
         'LICENSE',
         'README.md',
         'eslint.config.mjs',
         'package.json',
-        'tsconfig.json',
         'pnpm-lock.yaml',
+        'tsconfig.json',
       ])
     })
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -75,7 +75,7 @@ export function setupTest(testName: string) {
 }
 
 export async function getTestDirPaths(testDir: string) {
-  const testDirPaths = await glob(path.join(testDir, '**/*'), { absolute: true, dot: true, filesOnly: true })
+  const testDirPaths = await glob('**/*', { cwd: testDir, absolute: true, dot: true, filesOnly: true })
 
   return testDirPaths.map((testDirPath) => testDirPath.replace(testDir, ''))
 }


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

This PR add supports for Windows:

- Run package manager commands with `pnpm.cmd` instead of `pnpm`
- Carefully uses globs (as globs on Windows are... [a pain](https://github.com/terkelg/tiny-glob#windows))
- Sort file list in lexicographic order (so the order is consistent and is not dependent on the platform)

**Why**

When running the creation utility on Windows, I was getting the following issue:
```
√ App name: ... tmp
√ App directory: ... current directory / new 'tmp' directory
√ Public npm package? (if public, a page to create an npm automation access token will be opened) ... yes / no
√ Create the application? ... yes
✔ Baking Git repository…
✔ Copying templates…
✔ Brewing package.json…
✔ Configuring TypeScript…
✔ Setting up ESLint…
✖ Installing dependencies…

Something went wrong: Unable to run command: 'pnpm install'.
Error: spawn pnpm ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn pnpm',
  path: 'pnpm',
  spawnargs: [ 'install' ]
}
```
After finding out that `pnpm.cmd` shall be used instead of `pnpm` ([reference](https://stackoverflow.com/a/43285131/263057)), I faced the next error (about glob).

**How**

- Testing which platform is it running (according to [possible values](https://nodejs.org/api/process.html#process_process_platform)): changing the executable named based on that
- Sorting and changing tiny-glob calls (on all platforms)

<!-- Feel free to add additional comments. -->
